### PR TITLE
fixed cli tool when setting wallet representative

### DIFF
--- a/pippin/pippin_cli.py
+++ b/pippin/pippin_cli.py
@@ -340,7 +340,7 @@ def main():
         elif options.command == 'wallet_representative_get':
             loop.run_until_complete(wallet_representative_get(options.wallet))
         elif options.command == 'wallet_representative_set':
-            loop.run_until_complete(wallet_representative_set(options.wallet, options.representatives, update_existing=options.update_existing))
+            loop.run_until_complete(wallet_representative_set(options.wallet, options.representative, update_existing=options.update_existing))
         else:
             parser.print_help()
     except Exception as e:


### PR DESCRIPTION
When using pippin-cli with python3.8 was getting error:
```
'Namespace' object has no attribute 'representatives'
Traceback (most recent call last):
  File ".local/bin/pippin-cli", line 8, in <module>
    sys.exit(main())
  File "/root/.local/lib/python3.8/site-packages/pippin/pippin_cli.py", line 348, in main
    raise e
  File "/root/.local/lib/python3.8/site-packages/pippin/pippin_cli.py", line 343, in main
    loop.run_until_complete(wallet_representative_set(options.wallet, options.representatives, update_existing=options.update_existing))
```

corrected from `options.representatives` to `option.representative`